### PR TITLE
Parte 4 (frontend): integra catálogo dinámico desde backend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3398,9 +3398,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.1.tgz",
-      "integrity": "sha512-/jjU3fcYNd2bwz9Q0xt5TwyiyoO8XjSEFXJY4O/lMAlkGTHWuHRAbR9Etik+lSDqMC7A7mz3UlXzgYT6Vl58sA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.2.tgz",
+      "integrity": "sha512-9Rw8r199klMnlGZ8VAsV/I8WrIF6IyJ90JQUdboupx1cdkgYqwnrYjH+I/nY/7cA1X5zia4mDJqH36npP7sxGQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3421,12 +3421,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.1.tgz",
-      "integrity": "sha512-5DPSPc7ENrt2tlKPq0FtpG80ZbqA9aIKEyqX6hSNJDlol/tr6iqCK4crqdsusmOSSotq6zDsn0y3urX9TuTNmA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.2.tgz",
+      "integrity": "sha512-yk1XW8Fj7gK7flpYBXF3yzd2NbX6P7Kxjvs2b5nu1M04rb5pg/Zc4fGdBNTeT4eDYL2bvzWNyKaIMJX/RKHTTg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.5.1"
+        "react-router": "7.5.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000,
+  },
 })


### PR DESCRIPTION
Este PR completa el Paso 4:

1. Nueva rama: feature/frontend-integration
2. Se añadió vite.config.js para forzar puerto 3000 en Vite.
3. Se creó frontend/.env con VITE_API_URL=http://localhost:3001.
4. CatalogView.jsx ahora consume GET /products vía fetch(import.meta.env.VITE_API_URL).
5. Manejo de estados loading/error en UI.

 Verificado en http://localhost:3000 consumiendo http://localhost:3001/products